### PR TITLE
upgrade metabase to 0.20.2

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-URL="https://github.com/metabase/metabase-deploy/raw/v0.20.2/target/uberjar/metabase.jar"
+URL="https://github.com/metabase/metabase-deploy/raw/v0.20.3/target/uberjar/metabase.jar"
 wget --progress=bar $URL -O metabase.jar

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
-URL="https://github.com/metabase/metabase-deploy/raw/v0.20.1/target/uberjar/metabase.jar"
+URL="https://github.com/metabase/metabase-deploy/raw/v0.20.2/target/uberjar/metabase.jar"
 wget --progress=bar $URL -O metabase.jar


### PR DESCRIPTION
whenever a new version of metabase becomes available, all we have to do is bump up this line here to link against the newer jar file
